### PR TITLE
Clarify why Sean Bean matters

### DIFF
--- a/sad-tale.md
+++ b/sad-tale.md
@@ -1,3 +1,3 @@
 House Stark of Winterfell is led by the just Eddard "Ned" Stark, Lord of
 Winterfell, Warden of the North, Hand of the King, Protector of the Realm,
-Regent.  He is surely honorable and will die, duh hes played by Sean Bean.
+Regent.  He is surely honorable and will die, duh hes played by Sean Bean. Sean Bean's character dies in every performance he does.


### PR DESCRIPTION
-added text to show why Sean Bean is relevant to Ned Stark's death.